### PR TITLE
Revert "chore(deps): update helm release metallb to v0.13.1"

### DIFF
--- a/cluster/core/metallb-system/helm-release.yaml
+++ b/cluster/core/metallb-system/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://metallb.github.io/metallb
       chart: metallb
-      version: 0.13.1
+      version: 0.12.1
       sourceRef:
         kind: HelmRepository
         name: metallb-charts


### PR DESCRIPTION
Reverts fernandopn/swarm#716

Images are broken for some reason  https://github.com/metallb/metallb/issues/1471